### PR TITLE
fix: 앱 스토어 커넥트 언어 변경

### DIFF
--- a/Cherish.xcodeproj/project.pbxproj
+++ b/Cherish.xcodeproj/project.pbxproj
@@ -366,10 +366,10 @@
 			};
 			buildConfigurationList = CC818CD12899ED8B003B8753 /* Build configuration list for PBXProject "Cherish" */;
 			compatibilityVersion = "Xcode 13.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				en,
+				ko,
 				Base,
 			);
 			mainGroup = CC818CCD2899ED8B003B8753;


### PR DESCRIPTION
[iOS ) 앱 스토어 Connect 언어 변경하기](https://rriver2.tistory.com/entry/iOS-%EC%95%B1-%EC%8A%A4%ED%86%A0%EC%96%B4-Connect-%EC%96%B8%EC%96%B4-%EB%B3%80%EA%B2%BD%ED%95%98%EA%B8%B0) 참고
